### PR TITLE
Fix syntax colors in string interpolation

### DIFF
--- a/index.less
+++ b/index.less
@@ -171,6 +171,10 @@
   background-color: #0E2231;
 }
 
+.meta.embedded.line, .meta.embedded.line .string {
+  color: #DAEFA3;
+}
+
 .markup.deleted {
   color: #F8F8F8;
   background-color: #420E09;


### PR DESCRIPTION
Hello, thanks for porting Twilight to Atom.io!

I have a small issue with string interpolations in Ruby.
Here is a screenshot:

![before](https://f.cloud.github.com/assets/337347/2310083/f8627d52-a2de-11e3-9ee1-5a95555a3e3f.png)

Here is what I have with Sublime Text 2 / Twilight:

![sublime](https://f.cloud.github.com/assets/337347/2310104/2f3586bc-a2df-11e3-92a8-e83506bdab47.png)

And here is what I have in Atom after fixing the css rules with my commit:

![atom](https://f.cloud.github.com/assets/337347/2310126/6a187b86-a2df-11e3-9a54-3aa2c6211de9.png)
