### PR TITLE
Add a border to other marked regions

### DIFF
--- a/index.less
+++ b/index.less
@@ -24,6 +24,10 @@
   background-color: rgba(166, 148, 66, 0);
 }
 
+.editor .search-results .marker:not(.current-result) .region {
+  border: 1px solid #888888;
+}
+
 .comment {
   font-style: italic;
   color: #5F5A60;


### PR DESCRIPTION
When performing a find/replace, all additional results are highlighted with a border

Before:
![screen shot 2014-05-12 at 9 13 50 pm](https://cloud.githubusercontent.com/assets/945258/2952599/46aaeb6a-da3f-11e3-960d-32d10b518065.png)

After:
![screen shot 2014-05-12 at 9 13 22 pm](https://cloud.githubusercontent.com/assets/945258/2952603/5713d0e8-da3f-11e3-87ae-a53d30c9edf6.png)
