### PR TITLE
Make compatible with atom-text-editor shadow DOM

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,26 +1,32 @@
-.editor .wrap-guide {
+.editor .wrap-guide,
+:host .wrap-guide {
   background-color: #ffffff;
   opacity: 0.07;
 }
 
-.editor .indent-guide {
+.editor .indent-guide,
+:host .indent-guide {
   opacity: 0.1;
 }
 
-.editor, .editor .gutter {
+.editor, .editor .gutter,
+:host, :host .gutter {
   background-color: #141414;
   color: #F8F8F8;
 }
 
-.editor.is-focused .cursor {
+.editor.is-focused .cursor,
+:host(.is-focused) .cursor {
   border-color: #A7A7A7;
 }
 
-.editor.is-focused .selection .region {
+.editor.is-focused .selection .region,
+:host(.is-focused) .selection .region {
   background-color: rgba(221, 240, 255, 0.2);
 }
 
-.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line {
+.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line,
+:host(.is-focused) .line-number.cursor-line-no-selection, :host(.is-focused) .line.cursor-line {
   background-color: rgba(166, 148, 66, 0);
 }
 


### PR DESCRIPTION
As discussed in our latest [blog post](http://blog.atom.io/2014/11/18/avoiding-style-pollution-with-the-shadow-dom.html), we'll be transitioning Atom's text editor to use the shadow DOM to avoid accidental styling conflicts. Since you have a really popular syntax theme, I thought I'd save you the trouble of reading through our [upgrade guide](https://atom.io/docs/v0.147.0/upgrading/upgrading-your-syntax-theme) and just make the changes for you. Please check to make sure everything works just in case I missed something specific to your theme, but this should be straightforward. Thanks!
