### PR TITLE
Fix v1.13.0 Atom Deprecations

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,4 +1,4 @@
-atom-text-editor, :host {
+atom-text-editor, atom-text-editor {
 
   background-color: #141414;
   color: #F8F8F8;
@@ -37,176 +37,176 @@ atom-text-editor, :host {
 
 }
 
-.comment {
+.syntax--comment {
   font-style: italic;
   color: #5F5A60;
 }
 
-.constant {
+.syntax--constant {
   color: #CF6A4C;
 }
 
-.entity {
+.syntax--entity {
   color: #9B703F;
 }
 
-.keyword {
+.syntax--keyword {
   color: #CDA869;
 }
 
-.storage {
+.syntax--storage {
   color: #F9EE98;
 }
 
-.string {
+.syntax--string {
   color: #8F9D6A;
 }
 
-.support {
+.syntax--support {
   color: #9B859D;
 }
 
-.variable {
+.syntax--variable {
   color: #7587A6;
 }
 
-.invalid.deprecated {
+.syntax--invalid.syntax--deprecated {
   font-style: italic;
   text-decoration: underline;
   color: #D2A8A1;
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
   color: #F8F8F8;
   background-color: rgba(86, 45, 86, 0.75);
 }
 
-.text .source {
+.syntax--text .syntax--source {
   background-color: rgba(176, 179, 186, 0.08);
 }
 
-.text.html.ruby .source {
+.syntax--text.syntax--html.syntax--ruby .syntax--source {
   background-color: rgba(177, 179, 186, 0.13);
 }
 
-.entity.other.inherited-class {
+.syntax--entity.syntax--other.syntax--inherited-class {
   font-style: italic;
   color: #9B5C2E;
 }
 
-.string .source {
+.syntax--string .syntax--source {
   color: #DAEFA3;
 }
 
-.string .constant {
+.syntax--string .syntax--constant {
   color: #DDF2A4;
 }
 
-.string.regexp {
+.syntax--string.syntax--regexp {
   color: #E9C062;
 }
 
-.string.regexp .constant.character.escape, .string.regexp .source.ruby.embedded, .string.regexp .string.regexp.arbitrary-repitition {
+.syntax--string.syntax--regexp .syntax--constant.syntax--character.syntax--escape, .syntax--string.syntax--regexp .syntax--source.syntax--ruby.syntax--embedded, .syntax--string.syntax--regexp .syntax--string.syntax--regexp.syntax--arbitrary-repitition {
   color: #CF7D34;
 }
 
-.string .variable {
+.syntax--string .syntax--variable {
   color: #8A9A95;
 }
 
-.support.function {
+.syntax--support.syntax--function {
   color: #DAD085;
 }
 
-.support.constant {
+.syntax--support.syntax--constant {
   color: #CF6A4C;
 }
 
-.meta.preprocessor.c {
+.syntax--meta.syntax--preprocessor.syntax--c {
   color: #8996A8;
 }
 
-.meta.preprocessor.c .keyword {
+.syntax--meta.syntax--preprocessor.syntax--c .syntax--keyword {
   color: #AFC4DB;
 }
 
-.meta.tag.sgml.doctype, .meta.tag.sgml.doctype .entity, .meta.tag.sgml.doctype .string, .meta.tag.preprocessor.xml, .meta.tag.preprocessor.xml .entity, .meta.tag.preprocessor.xml .string {
+.syntax--meta.syntax--tag.syntax--sgml.syntax--doctype, .syntax--meta.syntax--tag.syntax--sgml.syntax--doctype .syntax--entity, .syntax--meta.syntax--tag.syntax--sgml.syntax--doctype .syntax--string, .syntax--meta.syntax--tag.syntax--preprocessor.syntax--xml, .syntax--meta.syntax--tag.syntax--preprocessor.syntax--xml .syntax--entity, .syntax--meta.syntax--tag.syntax--preprocessor.syntax--xml .syntax--string {
   color: #494949;
 }
 
-.declaration.tag, .declaration.tag .entity, .meta.tag, .meta.tag .entity {
+.syntax--declaration.syntax--tag, .syntax--declaration.syntax--tag .syntax--entity, .syntax--meta.syntax--tag, .syntax--meta.syntax--tag .syntax--entity {
   color: #AC885B;
 }
 
-.declaration.tag.inline, .declaration.tag.inline .entity, .source .entity.name.tag, .source .entity.other.attribute-name, .meta.tag.inline, .meta.tag.inline .entity {
+.syntax--declaration.syntax--tag.syntax--inline, .syntax--declaration.syntax--tag.syntax--inline .syntax--entity, .syntax--source .syntax--entity.syntax--name.syntax--tag, .syntax--source .syntax--entity.syntax--other.syntax--attribute-name, .syntax--meta.syntax--tag.syntax--inline, .syntax--meta.syntax--tag.syntax--inline .syntax--entity {
   color: #E0C589;
 }
 
-.meta.selector.css .entity.name.tag {
+.syntax--meta.syntax--selector.syntax--css .syntax--entity.syntax--name.syntax--tag {
   color: #CDA869;
 }
 
-.meta.selector.css .entity.other.attribute-name.tag.pseudo-class {
+.syntax--meta.syntax--selector.syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--tag.syntax--pseudo-class {
   color: #8F9D6A;
 }
 
-.meta.selector.css .entity.other.attribute-name.id {
+.syntax--meta.syntax--selector.syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--id {
   color: #8B98AB;
 }
 
-.meta.selector.css .entity.other.attribute-name.class {
+.syntax--meta.syntax--selector.syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--class {
   color: #9B703F;
 }
 
-.support.type.property-name.css {
+.syntax--support.syntax--type.syntax--property-name.syntax--css {
   color: #C5AF75;
 }
 
-.meta.property-group .support.constant.property-value.css, .meta.property-value .support.constant.property-value.css {
+.syntax--meta.syntax--property-group .syntax--support.syntax--constant.syntax--property-value.syntax--css, .syntax--meta.syntax--property-value .syntax--support.syntax--constant.syntax--property-value.syntax--css {
   color: #F9EE98;
 }
 
-.meta.preprocessor.at-rule .keyword.control.at-rule {
+.syntax--meta.syntax--preprocessor.syntax--at-rule .syntax--keyword.syntax--control.syntax--at-rule {
   color: #8693A5;
 }
 
-.meta.property-value .support.constant.named-color.css, .meta.property-value .constant {
+.syntax--meta.syntax--property-value .syntax--support.syntax--constant.syntax--named-color.syntax--css, .syntax--meta.syntax--property-value .syntax--constant {
   color: #CA7840;
 }
 
-.meta.constructor.argument.css {
+.syntax--meta.syntax--constructor.syntax--argument.syntax--css {
   color: #8F9D6A;
 }
 
-.meta.diff, .meta.diff.header, .meta.separator {
+.syntax--meta.syntax--diff, .syntax--meta.syntax--diff.syntax--header, .syntax--meta.syntax--separator {
   font-style: italic;
   color: #F8F8F8;
   background-color: #0E2231;
 }
 
-.meta.embedded.line, .meta.embedded.line .string {
+.syntax--meta.syntax--embedded.syntax--line, .syntax--meta.syntax--embedded.syntax--line .syntax--string {
   color: #DAEFA3;
 }
 
-.markup.deleted {
+.syntax--markup.syntax--deleted {
   color: #F8F8F8;
   background-color: #420E09;
 }
 
-.markup.changed {
+.syntax--markup.syntax--changed {
   color: #F8F8F8;
   background-color: #4A410D;
 }
 
-.markup.inserted {
+.syntax--markup.syntax--inserted {
   color: #F8F8F8;
   background-color: #253B22;
 }
 
-.markup.list {
+.syntax--markup.syntax--list {
   color: #F9EE98;
 }
 
-.markup.heading {
+.syntax--markup.syntax--heading {
   color: #CF6A4C;
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "repository": "https://github.com/cannikin/twilight-syntax",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">1.13.0"
   }
 }


### PR DESCRIPTION
This pull request updates the syntax based on the deprecation warnings from the Atom Deprecation Cop. I haven't worked on an Atom theme before so if I've misinterpreted the deprecations or made a mistake, please feel free to close this pull request.

I also updated the atom engine version to `">1.13.0"` in package.json, please let me know if that isn't correct.

Thank you for your work on this port, this is my favorite syntax theme!


Relevant Issues:
https://github.com/cannikin/twilight-syntax/issues/10